### PR TITLE
WIP Features/mixify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 erl_crash.dump
 *.ez
 razor
+/razor_archives

--- a/lib/mix/tasks/razor.new.ex
+++ b/lib/mix/tasks/razor.new.ex
@@ -4,17 +4,13 @@ defmodule Mix.Tasks.Razor.New do
   use Mix.Task
 
   def run(args) do
+    {:ok, _started} = Application.ensure_all_started(:razor)
 
     dir = List.first(args)
     name = List.last(String.split(dir, "/"))
 
     Logger.info("razor.new dir: #{dir}; name: #{name}")
 
-    # FIXME: Why doesn't this work?
-    # Razor.Zapper.zap(name, dir)
-
-    razor_cmd = "#{File.cwd!}/razor"    
-    Logger.info("Running with #{razor_cmd}.")   
-    {_, 0} = System.cmd(razor_cmd, ["--name", name, "--dir", dir])
+    Razor.Zapper.zap(name, dir)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,12 +1,15 @@
 defmodule Razor.Mixfile do
   use Mix.Project
 
+  @version "0.0.2"
+  
   def project do
     [app: :razor,
-     version: "0.0.1",
+     version: @version,
      elixir: "~> 1.4.2",
      escript: [main_module: Razor],
-     deps: deps()]
+     deps: deps(),
+     aliases: aliases()]
   end
 
   # Configuration for the OTP application
@@ -30,6 +33,20 @@ defmodule Razor.Mixfile do
       {:httpoison, "~> 0.11.1"},
       {:poison, "~> 3.1"},
       {:inflex, "~> 1.8"}      
+    ]
+  end
+
+  defp build_releases(_) do
+    Mix.Tasks.Compile.run([])
+    Mix.Tasks.Archive.Build.run([])
+    Mix.Tasks.Archive.Build.run(["--output=razor.ez"])
+    File.rename("razor.ez", "./razor-archives/razor.ez")
+    File.rename("razor-#{@version}.ez", "./razor-archives/razor-#{@version}.ez")
+  end
+
+  defp aliases do
+    [
+      build: [ &build_releases/1]
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
-%{"certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], []},
-  "hackney": {:hex, :hackney, "1.7.1", "e238c52c5df3c3b16ce613d3a51c7220a784d734879b1e231c9babd433ac1cb4", [:rebar3], [{:certifi, "1.0.0", [hex: :certifi, optional: false]}, {:idna, "4.0.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
-  "httpoison": {:hex, :httpoison, "0.11.1", "d06c571274c0e77b6cc50e548db3fd7779f611fbed6681fd60a331f66c143a0b", [:mix], [{:hackney, "~> 1.7.0", [hex: :hackney, optional: false]}]},
-  "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], []},
-  "inflex": {:hex, :inflex, "1.8.0", "7cfc752ae244b30b42ac9cf4c092771b485bc3424139aba4a933e54be8c63931", [:mix], []},
-  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
-  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}
+%{"certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], [], "hexpm"},
+  "hackney": {:hex, :hackney, "1.7.1", "e238c52c5df3c3b16ce613d3a51c7220a784d734879b1e231c9babd433ac1cb4", [:rebar3], [{:certifi, "1.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "4.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
+  "httpoison": {:hex, :httpoison, "0.11.1", "d06c571274c0e77b6cc50e548db3fd7779f611fbed6681fd60a331f66c143a0b", [:mix], [{:hackney, "~> 1.7.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
+  "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], [], "hexpm"},
+  "inflex": {:hex, :inflex, "1.8.0", "7cfc752ae244b30b42ac9cf4c092771b485bc3424139aba4a933e54be8c63931", [:mix], [], "hexpm"},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"}}


### PR DESCRIPTION
This PR creates two new mix tasks:

+ `mix razor.new path/to/application`will create `application` at the specified path.

+ `MIX_ENV=prod mix build` will build two new releases, one with version in the name.

The build process could be more efficient by copying rather than building twice. All of this information should go into the README.

Once a release has been created, you can install it locally with `mix archive.install path/to/razor.ez`.

Then `mix razor.new new-app` will run. However, for some reason I don't yet understand, this leads to an error.

Be aware that once the archive is installed, `mix razor.new …` will run the installed version rather than the project version, so you may need to uninstall while developing.

I'm creating this PR since the `razor.new` mix task is an incremental improvement, and in case anyone else can debug the remaining error.