### PR TITLE
Update readme to include a link to prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Phoenix application generator that builds a new project skeleton configured with
 
 Razor generates Phoenix projects by cloning a prototype app and massaging it gently into shape.
 
-What's in the box? 
+What's in the box?
 - Phoenix
 - Postgrex
 - Slim

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ If you want to install to a directory named differently from the app,
 
 _Windows users - your executable may be `razor.bat` instead of `razor`_
 
+## Next steps: deploying your new app, running locally, & c.
+
+_See the prototype repository: [carbonfive/razor-phoenix](https://github.com/carbonfive/razor-phoenix) for more info_
+
 ## Linting
 * `mix credo --strict`
 


### PR DESCRIPTION
Add a "Next steps" section to the README to direct users to the razor-phoenix prototype README for info about how to deploy and run the server locally.